### PR TITLE
Configure ./viz-lib as a public npm package

### DIFF
--- a/viz-lib/package.json
+++ b/viz-lib/package.json
@@ -1,5 +1,29 @@
 {
   "dependencies": {
     "d3": "^7.8.5"
-  }
+  },
+  "name": "@kimyuh/viz-lib",
+  "version": "0.0.0",
+  "description": "Lightweight library of visual and harmonic renderings aimed to please the eye and stimulate the mind. Improve the your aesthetic to anything web using viz-lib.",
+  "main": "lib.js",
+  "devDependencies": {},
+  "scripts": {
+    "test": "echo 'unsupported'"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/JtSangerman/viz-lib.git#feature\/create-npm-package-for-vizlib"
+  },
+  "keywords": [
+    "pleasant",
+    "visuals",
+    "for",
+    "u"
+  ],
+  "author": "jtsangerman, marcus-kim",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/JtSangerman/viz-lib/issues"
+  },
+  "homepage": "https://github.com/JtSangerman/viz-lib#readme"
 }

--- a/viz-lib/package.json
+++ b/viz-lib/package.json
@@ -2,7 +2,7 @@
   "dependencies": {
     "d3": "^7.8.5"
   },
-  "name": "@kimyuh/viz-lib",
+  "name": "@jimyuh/viz-lib",
   "version": "0.0.0",
   "description": "Lightweight library of visual and harmonic renderings aimed to please the eye and stimulate the mind. Improve the your aesthetic to anything web using viz-lib.",
   "main": "lib.js",


### PR DESCRIPTION
https://www.npmjs.com/package/@jimyuh/viz-lib

Made an organization "@jimyuh" (kimjuh + jamie = jimyuh). Make an npmjs.com user and I will add you as an owner, and you can then publish new versions to it.

I just officially published this /viz-lib as a public package, so v0.0.0 is officially available on npm!🎉 

Install via npm as you would any other `npm i @jimyuh/viz-lib` and add any viz from the library to anything web!